### PR TITLE
Make Collection Importable into Galaxy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: maxamillion
 name: fleetmanager
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.0
+version: 0.1.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -24,11 +24,6 @@ authors:
 
 # A short summary description of the collection
 description: PoC Collection for Red Hat Fleet Manager
-
-# Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
-# accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
-license:
-- MIT
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,3 @@
+---
+
+requires_ansible: ">=2.11"


### PR DESCRIPTION
This PR allows this collection to be imported to a galaxy server by fixing two issues:
1. Creation of a runtime.yml file within meta/
2. Removing of the 'license' key from galaxy.yml, which is mutually exclusive with license_file

Version has been bumped to '0.1.1' to reflect changes